### PR TITLE
Support Nvidia GTX 10 series (Pascal)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,37 +63,37 @@ jobs:
             config: "--config=cuda"
             artifact: libpjrt_c_api_gpu_plugin.so
             renamed_artifact: libpjrt_cuda.so
-            runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
+            runs_on: ubuntu-latest
             platform: linux-amd64
             bazel_target: //xla/pjrt/c:pjrt_c_api_gpu_plugin
-          - target: rocm
-            config: "--config=rocm"
-            artifact: libpjrt_c_api_gpu_plugin.so
-            renamed_artifact: libpjrt_rocm.so
-            runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
-            platform: linux-amd64
-            bazel_target: //xla/pjrt/c:pjrt_c_api_gpu_plugin
-          - target: cpu
-            config: "--config=release_macos_arm64"
-            artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
-            runs_on: ["self-hosted", "macOS"]
-            renamed_artifact: libpjrt_cpu.dylib
-            platform: darwin-arm64
-            bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
-          - target: cpu
-            config: "--config=release_macos_base"
-            artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
-            renamed_artifact: libpjrt_cpu.dylib
-            runs_on: ["self-hosted", "macOS"]
-            platform: darwin-amd64
-            bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
-          - target: cpu
-            config: "--remote_cache=grpc://127.0.0.1:15501"
-            artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.so
-            renamed_artifact: libpjrt_cpu.so
-            runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
-            platform: linux-amd64
-            bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
+          # - target: rocm
+          #   config: "--config=rocm"
+          #   artifact: libpjrt_c_api_gpu_plugin.so
+          #   renamed_artifact: libpjrt_rocm.so
+          #   runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
+          #   platform: linux-amd64
+          #   bazel_target: //xla/pjrt/c:pjrt_c_api_gpu_plugin
+          # - target: cpu
+          #   config: "--config=release_macos_arm64"
+          #   artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
+          #   runs_on: ["self-hosted", "macOS"]
+          #   renamed_artifact: libpjrt_cpu.dylib
+          #   platform: darwin-arm64
+          #   bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
+          # - target: cpu
+          #   config: "--config=release_macos_base"
+          #   artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
+          #   renamed_artifact: libpjrt_cpu.dylib
+          #   runs_on: ["self-hosted", "macOS"]
+          #   platform: darwin-amd64
+          #   bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
+          # - target: cpu
+          #   config: "--remote_cache=grpc://127.0.0.1:15501"
+          #   artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.so
+          #   renamed_artifact: libpjrt_cpu.so
+          #   runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
+          #   platform: linux-amd64
+          #   bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
 
     needs: ["setup_openxla"]
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,37 +63,37 @@ jobs:
             config: "--config=cuda"
             artifact: libpjrt_c_api_gpu_plugin.so
             renamed_artifact: libpjrt_cuda.so
-            runs_on: ubuntu-latest
+            runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
             platform: linux-amd64
             bazel_target: //xla/pjrt/c:pjrt_c_api_gpu_plugin
-          # - target: rocm
-          #   config: "--config=rocm"
-          #   artifact: libpjrt_c_api_gpu_plugin.so
-          #   renamed_artifact: libpjrt_rocm.so
-          #   runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
-          #   platform: linux-amd64
-          #   bazel_target: //xla/pjrt/c:pjrt_c_api_gpu_plugin
-          # - target: cpu
-          #   config: "--config=release_macos_arm64"
-          #   artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
-          #   runs_on: ["self-hosted", "macOS"]
-          #   renamed_artifact: libpjrt_cpu.dylib
-          #   platform: darwin-arm64
-          #   bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
-          # - target: cpu
-          #   config: "--config=release_macos_base"
-          #   artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
-          #   renamed_artifact: libpjrt_cpu.dylib
-          #   runs_on: ["self-hosted", "macOS"]
-          #   platform: darwin-amd64
-          #   bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
-          # - target: cpu
-          #   config: "--remote_cache=grpc://127.0.0.1:15501"
-          #   artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.so
-          #   renamed_artifact: libpjrt_cpu.so
-          #   runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
-          #   platform: linux-amd64
-          #   bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
+          - target: rocm
+            config: "--config=rocm"
+            artifact: libpjrt_c_api_gpu_plugin.so
+            renamed_artifact: libpjrt_rocm.so
+            runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
+            platform: linux-amd64
+            bazel_target: //xla/pjrt/c:pjrt_c_api_gpu_plugin
+          - target: cpu
+            config: "--config=release_macos_arm64"
+            artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
+            runs_on: ["self-hosted", "macOS"]
+            renamed_artifact: libpjrt_cpu.dylib
+            platform: darwin-arm64
+            bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
+          - target: cpu
+            config: "--config=release_macos_base"
+            artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.dylib
+            renamed_artifact: libpjrt_cpu.dylib
+            runs_on: ["self-hosted", "macOS"]
+            platform: darwin-amd64
+            bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
+          - target: cpu
+            config: "--remote_cache=grpc://127.0.0.1:15501"
+            artifact: bazel-bin/xla/pjrt/c/libpjrt_c_api_cpu_plugin.so
+            renamed_artifact: libpjrt_cpu.so
+            runs_on: ["runs-on", "runner=32cpu-linux-x64", "image=ubuntu22-amd64"]
+            platform: linux-amd64
+            bazel_target: //xla/pjrt/c:pjrt_c_api_cpu_plugin
 
     needs: ["setup_openxla"]
     steps:

--- a/openxla/bazelrc/cuda.bazelrc
+++ b/openxla/bazelrc/cuda.bazelrc
@@ -7,7 +7,7 @@ build      --build_tag_filters -no_oss
 build      --test_tag_filters -no_oss
 build      --config nvcc_clang
 build      --action_env CLANG_CUDA_COMPILER_PATH=/usr/lib/llvm-18/bin/clang
-build:cuda --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES=8.9
+build:cuda --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_61,sm_70,sm_80,compute_90"
 build:cuda --repo_env=HERMETIC_CUDA_VERSION="12.6.3"
 build:cuda --repo_env=HERMETIC_CUDNN_VERSION="9.6.0"
 build:cuda --@//xla/stream_executor/cuda:enable_libnvjitlink_support=True 
@@ -15,4 +15,3 @@ build:cuda --@//xla/stream_executor/cuda:enable_libnvptxcompiler_support=True
 
 test       --build_tag_filters -no_oss
 test       --test_tag_filters -no_oss
-


### PR DESCRIPTION
This PR updates the CUDA compute capabilities configuration to include support for older GTX series. This enable me to run ZML Llama example in my homelab (Ubuntu Server, GTX 1070 Ti).

### Fixing error : 
```logs
Could not create RepeatBufferKernel: INTERNAL: CUDA Runtime error: Failed call to cudaGetFuncBySymbol: cudaErrorNoKernelImageForDevice: no kernel image is available for execution on the device
```
https://github.com/zml/zml/issues/19#issuecomment-2504568488

Before : 
```logs
victor@homelab ~/develop/zml/examples [master] $ bazel run -c opt --@zml//runtimes:cuda=true //llama:Llama-3.2-1B-Instruct -- --prompt="Tell me a story about a pirate ?"
INFO: Analyzed target //llama:Llama-3.2-1B-Instruct (57 packages loaded, 9382 targets configured).
INFO: Found 1 target...
Target //llama:Llama-3.2-1B-Instruct up-to-date:
  bazel-bin/llama/Llama-3.2-1B-Instruct
INFO: Elapsed time: 15.328s, Critical Path: 0.89s
INFO: 1 process: 2226 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/llama/Llama-3.2-1B-Instruct '--config=../zml++huggingface+Meta-Llama-3.2-1B-Instruct/config.json' '--weights=../zml++huggingface+Meta-Llama-3.2-1B-Instruct/model.safetensors' '--tokenizer=../zml++huggingface+Meta-Llama-3.2-1B-Instruct/tokenizer.json' <args omitted>
info(llama):    LLama was compiled with builtin.OptimizeMode.ReleaseSafe
info(pjrt): Loaded library: libpjrt_cpu.so
info(pjrt): Loaded library: libpjrt_cuda.so
info(zml/context): Available Platforms:
info(zml/context):   •  cpu 
info(zml/context):   ✅ cuda (AUTO-SELECTED)
info(zml/context):        ◦ #0: NVIDIA GeForce GTX 1070 Ti
info(zml/context):   •  rocm 
info(zml/context):   •  tpu 
info(zml/context):   •  neuron 
info(zml): Compiling llama.LlamaLM.forward with { Shape({s=256,u32}), Shape({u32}), meta.MapType(tensor.Tensor,shape.Shape).map(llama.KvCache){ .k = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .v = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .layer_index = Shape({u32}) }, meta.MapType(tensor.Tensor,shape.Shape).map(tensor.Tensor.Rng){ ._state = Shape({2,u64}), .algorithm = stablehlo.RngAlgorithm.Type.DEFAULT } }
info(llama): 	Loading Llama weights from ../zml++huggingface+Meta-Llama-3.2-1B-Instruct/model.safetensors...
info(zml): Compiling llama.LlamaLM.forward with { Shape({s=1,u32}), Shape({u32}), meta.MapType(tensor.Tensor,shape.Shape).map(llama.KvCache){ .k = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .v = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .layer_index = Shape({u32}) }, meta.MapType(tensor.Tensor,shape.Shape).map(tensor.Tensor.Rng){ ._state = Shape({2,u64}), .algorithm = stablehlo.RngAlgorithm.Type.DEFAULT } }
info(zml/module): Wrote MLIR to /tmp/zml/llama/cuda/llama.LlamaLM.forward_26a5fcaf0f929ece/module.mlir
info(zml/module): Wrote MLIR to /tmp/zml/llama/cuda/llama.LlamaLM.forward_8238b59f6631dc9e/module.mlir
2025-02-26 08:14:27.776397: I xla/service/dump.cc:569] HloModule dump enabled with path prefix: , suffix: before_optimizations
F0226 08:14:28.028388    4090 stream_executor_util.cc:503] Could not create RepeatBufferKernel: INTERNAL: CUDA Runtime error: Failed call to cudaGetFuncBySymbol: cudaErrorNoKernelImageForDevice: no kernel image is available for execution on the device
info(llama): ✅	Loaded weights in 904.03ms
*** Check failure stack trace: ***
    @     0x757e14e7bd14  absl::lts_20230802::log_internal::LogMessage::SendToLog()
    @     0x757e14e7bb84  absl::lts_20230802::log_internal::LogMessage::Flush()
    @     0x757e14e7c0b9  absl::lts_20230802::log_internal::LogMessageFatal::~LogMessageFatal()
    @     0x757e1285fd70  xla::gpu::InitializeTypedBuffer<>()
    @     0x757e1285a98c  xla::primitive_util::FloatingPointTypeSwitch<>()
    @     0x757e12858fd1  xla::gpu::InitializeBuffer()
    @     0x757e117560c0  stream_executor::RedzoneAllocator::CreateBuffer()
    @     0x757e0fec93a3  xla::gpu::RedzoneBuffers::CreateInputs()
    @     0x757e0fec9005  xla::gpu::RedzoneBuffers::FromInstruction()
    @     0x757e0feae1c0  xla::gpu::(anonymous namespace)::GemmAutotuner::operator()()
    @     0x757e0feadf9b  std::_Function_handler<>::_M_invoke()
    @     0x757e0feccf2e  xla::gpu::AutotunerUtil::Autotune()
    @     0x757e0fead356  xla::gpu::GemmAlgorithmPicker::Run()
    @     0x757e0fed440f  xla::HloPassPipeline::RunHelper()
    @     0x757e0fed1822  xla::HloPassPipeline::RunPassesInternal<>()
    @     0x757e0fed111a  xla::HloPassPipeline::Run()
    @     0x757e0caa598e  xla::gpu::GpuCompiler::OptimizeHloPostLayoutAssignment()
    @     0x757e0ca92b9f  xla::gpu::NVPTXCompiler::OptimizeHloPostLayoutAssignment()
    @     0x757e0caa0d85  xla::gpu::GpuCompiler::OptimizeHloModule()
    @     0x757e0caaa57d  xla::gpu::GpuCompiler::RunHloPasses()
    @     0x757e0ca7f76d  xla::Service::BuildExecutable()
    @     0x757e0c861a2b  xla::LocalService::CompileExecutables()
    @     0x757e0c85ec64  xla::LocalClient::Compile()
    @     0x757e0c80b503  xla::PjRtStreamExecutorClient::CompileInternal()
    @     0x757e0c80c82a  xla::PjRtStreamExecutorClient::Compile()
    @     0x757e0c796998  std::__detail::__variant::__gen_vtable_impl<>::__visit_invoke()
    @     0x757e0c785f78  pjrt::PJRT_Client_Compile()
    @          0x1644498  async.callBlocking__anon_19089.TaskT.run
```

After : 
```logs
victor@homelab ~/develop/zml/examples [master] $ bazel run -c opt --@zml//runtimes:cuda=true //llama:Llama-3.2-1B-Instruct -- --prompt="Tell me a story about a pirate ?"
INFO: Analyzed target //llama:Llama-3.2-1B-Instruct (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //llama:Llama-3.2-1B-Instruct up-to-date:
  bazel-bin/llama/Llama-3.2-1B-Instruct
INFO: Elapsed time: 0.145s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/llama/Llama-3.2-1B-Instruct '--config=../zml++huggingface+Meta-Llama-3.2-1B-Instruct/config.json' '--weights=../zml++huggingface+Meta-Llama-3.2-1B-Instruct/model.safetensors' '--tokenizer=../zml++huggingface+Meta-Llama-3.2-1B-Instruct/tokenizer.json' <args omitted>
info(llama):    LLama was compiled with builtin.OptimizeMode.ReleaseSafe
info(pjrt): Loaded library: libpjrt_cpu.so
info(pjrt): Loaded library: libpjrt_cuda.so
info(zml/context): Available Platforms:
info(zml/context):   •  cpu 
info(zml/context):   ✅ cuda (AUTO-SELECTED)
info(zml/context):        ◦ #0: NVIDIA GeForce GTX 1070 Ti
info(zml/context):   •  rocm 
info(zml/context):   •  tpu 
info(zml/context):   •  neuron 
info(zml): Compiling llama.LlamaLM.forward with { Shape({s=256,u32}), Shape({u32}), meta.MapType(tensor.Tensor,shape.Shape).map(llama.KvCache){ .k = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .v = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .layer_index = Shape({u32}) }, meta.MapType(tensor.Tensor,shape.Shape).map(tensor.Tensor.Rng){ ._state = Shape({2,u64}), .algorithm = stablehlo.RngAlgorithm.Type.DEFAULT } }
info(llama): 	Loading Llama weights from ../zml++huggingface+Meta-Llama-3.2-1B-Instruct/model.safetensors...
info(zml): Compiling llama.LlamaLM.forward with { Shape({s=1,u32}), Shape({u32}), meta.MapType(tensor.Tensor,shape.Shape).map(llama.KvCache){ .k = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .v = Shape({layer=16,k=256,h=8!,hd=64,bf16}), .layer_index = Shape({u32}) }, meta.MapType(tensor.Tensor,shape.Shape).map(tensor.Tensor.Rng){ ._state = Shape({2,u64}), .algorithm = stablehlo.RngAlgorithm.Type.DEFAULT } }
info(zml/module): Wrote MLIR to /tmp/zml/llama/cuda/llama.LlamaLM.forward_26a5fcaf0f929ece/module.mlir
info(zml/module): Wrote MLIR to /tmp/zml/llama/cuda/llama.LlamaLM.forward_8238b59f6631dc9e/module.mlir
info(zml/module): Loaded pre-compiled module from /tmp/zml/llama/cuda/llama.LlamaLM.forward_26a5fcaf0f929ece/module.pjrt
info(zml/module): Loaded pre-compiled module from /tmp/zml/llama/cuda/llama.LlamaLM.forward_8238b59f6631dc9e/module.pjrt
info(llama): ✅	Loaded weights in 861.731ms
info(llama): ✅	Compiled model in 861.837ms
info(llama): Creating KvCache
info(llama): Loading tokenizer from ../zml++huggingface+Meta-Llama-3.2-1B-Instruct/tokenizer.json
info(llama): Loaded tokenizer from ../zml++huggingface+Meta-Llama-3.2-1B-Instruct/tokenizer.json [315.469ms]
info(llama): ✅	Prompt: Tell me a story about a pirate ?
Set sail for adventure with Captain Blackwood, the most feared pirate to ever sail the seven seas!

Captain Blackwood was a man of mystery and legend. His ship, the "Maverick's Revenge," was a hulking mass of wood and steel, with three masts and a hull that seemed to be carved from the very darkness of the ocean itself. His crew was a motley bunch, made up of seasoned sailors, scurvy dogs, and a few desperate souls who had lost everything to the pirate's life.

Blackwood's ship was crewed by the most feared pirates on the high seas. There was Barnaby Blackheart, the ship's bosun, who was as cunning as a fox and as ruthless as a snake. There was also Swill Bill, the ship's cook, who was as slippery as a snake and as deadly as a viper. And then there was the infamous pirate, Captain Cutlass, who was rumored to be the most feared pirate on the seas.

One fateful day, the Maverick's Revenge received a message from a mysterious stranger, claiming to have information about a hidden treasure on a remote island. The stranger,
info(llama): ✅ Generated 238 tokens in 1.326e1s: 17.952tok/s
```

### Documentation :

https://openxla.org/xla/hermetic_cuda#configure_hermetic_cuda

### Notes : 

This change increase the binary size (85.1 MB to 100 MB) and probably increase compile time.

**I have not yet tested this on newer GPUs**


If you want to test it : https://github.com/vctrmn/pjrt-artifacts/releases/tag/v6.0.1rc2 
